### PR TITLE
add empty callback if not given with options

### DIFF
--- a/viera.js
+++ b/viera.js
@@ -65,6 +65,8 @@
         var self = this;
         if(options !== undefined) {
             self.callback = options.callback;
+        } else {
+            self.callback = function () {};
         }
 
         var req = http.request(postRequest, function(res) {


### PR DESCRIPTION
Hey,
thank you very much for your node module. I like it very much, but it has an error. If sending a command it failed at 'res.on('data', self.callback);', because self.callback is not set. So I add an empty function, when it is not set. It would be very, very greate, if you add this to your module.